### PR TITLE
Improve Perceived Performance of Home & Shop

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "generate": "CI=1 nuxt-generate --fail-on-page-error -b"
   },
   "dependencies": {
-    "@nacelle/nacelle-nuxt-module": "0.0.229",
+    "@nacelle/nacelle-nuxt-module": "0.0.230",
     "@nuxtjs/apollo": "^4.0.0-rc8.2",
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/bulma": "^1.2.1",


### PR DESCRIPTION
To improve perceived performance of the `/` and `/shop` routes, don't blur-up the image in `ContentHeroBanner` by default.

A user can always add `:blur-up="true"` to a custom `<content-hero-banner>` if they wish.

### Demo Sites
NEW: https://stupefied-swartz-bd2b1c.netlify.com/

PREVIOUS: https://musing-bose-15178f.netlify.com/

### Relevant Commits
- [`nacelle-vue-components`](https://github.com/getnacelle/nacelle-vue-components/commit/3bec287f733eddaac62ba808f7e1598bf2b11ed1)
- [`nacelle-nuxt-module`](https://github.com/getnacelle/nacelle-nuxt-module/commit/bc7bb518e16fa1c70330c8e2181e7462db2beef1)
