### PR TITLE
HOTFIX: Prevent Image Resource Blocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "generate": "CI=1 nuxt-generate --fail-on-page-error -b"
   },
   "dependencies": {
-    "@nacelle/nacelle-nuxt-module": "0.0.230",
+    "@nacelle/nacelle-nuxt-module": "0.0.231",
     "@nuxtjs/apollo": "^4.0.0-rc8.2",
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/bulma": "^1.2.1",


### PR DESCRIPTION
HOTFIX to prevent resource blocking (& associated slow page load) caused by setting an image's `src` to an empty svg via `:data`. This also:
- disables component observability for `ContentHeroBanner` by default
- adds an option to set a placeholder image using the dominant color of the full-resolution image

### Relevant Commits:
- `nacelle-vue-components`
  - https://github.com/getnacelle/nacelle-vue-components/commit/494007dc8481c79dc5e2dd849e748864d3f6f0db
  - https://github.com/getnacelle/nacelle-vue-components/commit/2c18968024c6f70eae37c717b0674c92e83b941a
- `nacelle-nuxt-module`
  - https://github.com/getnacelle/nacelle-nuxt-module/commit/c2f411c76f61cea5e1a82e422b1c5138705a261a